### PR TITLE
ECVRF and ECVRFParam Structure

### DIFF
--- a/go/vrf/conversion_test.go
+++ b/go/vrf/conversion_test.go
@@ -58,8 +58,8 @@ func TestSEG1EncodeDecode(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	b := secg1EncodeCompressed(c, Ax, Ay)
-	Bx, By, err := secg1Decode(c, b)
+	b := marshalCompressed(c, Ax, Ay)
+	Bx, By, err := unmarshalCompressed(c, b)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/go/vrf/ecvrf.go
+++ b/go/vrf/ecvrf.go
@@ -48,17 +48,14 @@ func NewKey(curve elliptic.Curve, sk []byte) *PrivateKey {
 // ECVRFParams holds shared values across ECVRF implementations.
 // ECVRFParams also has generic algorithms that rely on ECVRFAux for specific sub algorithms.
 type ECVRFParams struct {
-	suiteString []byte         // single nonzero octet specifying the ECVRF ciphersuite
+	suiteString []byte         // Single nonzero octet specifying the ECVRF ciphersuite
 	ec          elliptic.Curve // Elliptic curve defined over F
-	//   G - subgroup of E of large prime order.
-	//   q - prime order of group G, ec.Params().N
-	//   B - generator of group G, ec.Params.{Gx,Gy}
-	n        int  // 2n  - length, in octets, of a field element in F.
-	ptLen    int  // length, in octets, of an EC point encoded as an octet string
-	qLen     int  // length of q in octets. (note that in the typical case, qLen equals 2n or is close to 2n)
-	cofactor byte //number of points on E divided by q
-	hash     crypto.Hash
-	aux      ECVRFAux // Auxiliary functions
+	n           int            // 2n is the length, in bytes, of a field element in F
+	ptLen       int            // Length, in octets, of an EC point encoded as an octet string
+	qLen        int            // Length of the prime order of the EC group in octets. (Typically ~2n)
+	cofactor    byte           // The number of points on EC divided by the prime order of the group
+	hash        crypto.Hash    // Cryptographic hash function
+	aux         ECVRFAux       // Suite specific helper functions
 }
 
 // ECVRFAux contains auxiliary functions nessesary for the computation of ECVRF.

--- a/go/vrf/ecvrf.go
+++ b/go/vrf/ecvrf.go
@@ -48,17 +48,17 @@ func NewKey(curve elliptic.Curve, sk []byte) *PrivateKey {
 // ECVRFParams holds shared values across ECVRF implementations.
 // ECVRFParams also has generic algorithms that rely on ECVRFAux for specific sub algorithms.
 type ECVRFParams struct {
-	suiteString []byte         // Single nonzero octet specifying the ECVRF ciphersuite
-	ec          elliptic.Curve // Elliptic curve defined over F
-	n           int            // 2n is the length, in bytes, of a field element in F
-	ptLen       int            // Length, in octets, of an EC point encoded as an octet string
-	qLen        int            // Length of the prime order of the EC group in octets. (Typically ~2n)
-	cofactor    byte           // The number of points on EC divided by the prime order of the group
-	hash        crypto.Hash    // Cryptographic hash function
-	aux         ECVRFAux       // Suite specific helper functions
+	suite    byte           // Single nonzero octet specifying the ECVRF ciphersuite.
+	ec       elliptic.Curve // Elliptic curve defined over F.
+	fieldLen int            // Length, in bytes, of a field element in F. Defined as 2n in spec.
+	ptLen    int            // Length, in bytes, of an EC point encoded as an octet string.
+	qLen     int            // Length, in bytes, of the prime order of the EC group (Typically ~fieldLen).
+	cofactor *big.Int       // The number of points on EC divided by the prime order of the group.
+	hash     crypto.Hash    // Cryptographic hash function.
+	aux      ECVRFAux       // Suite specific helper functions.
 }
 
-// ECVRFAux contains auxiliary functions nessesary for the computation of ECVRF.
+// ECVRFAux contains auxiliary functions necesary for the computation of ECVRF.
 type ECVRFAux interface {
 	// PointToString converts an EC point to an octet string.
 	PointToString(Px, Py *big.Int) []byte

--- a/go/vrf/ecvrf.go
+++ b/go/vrf/ecvrf.go
@@ -15,6 +15,7 @@
 package vrf
 
 import (
+	"crypto"
 	"crypto/elliptic"
 	"math/big"
 )
@@ -42,4 +43,38 @@ func NewKey(curve elliptic.Curve, sk []byte) *PrivateKey {
 		PublicKey: PublicKey{Curve: curve, X: x, Y: y}, // VRF public key Y = x*B
 		d:         new(big.Int).SetBytes(sk),           // Use SK to derive the VRF secret scalar x
 	}
+}
+
+// ECVRFParams holds shared values across ECVRF implementations.
+// ECVRFParams also has generic algorithms that rely on ECVRFAux for specific sub algorithms.
+type ECVRFParams struct {
+	suiteString []byte         // single nonzero octet specifying the ECVRF ciphersuite
+	ec          elliptic.Curve // Elliptic curve defined over F
+	//   G - subgroup of E of large prime order.
+	//   q - prime order of group G, ec.Params().N
+	//   B - generator of group G, ec.Params.{Gx,Gy}
+	n        int  // 2n  - length, in octets, of a field element in F.
+	ptLen    int  // length, in octets, of an EC point encoded as an octet string
+	qLen     int  // length of q in octets. (note that in the typical case, qLen equals 2n or is close to 2n)
+	cofactor byte //number of points on E divided by q
+	hash     crypto.Hash
+	aux      ECVRFAux // Auxiliary functions
+}
+
+// ECVRFAux contains auxiliary functions nessesary for the computation of ECVRF.
+type ECVRFAux interface {
+	// PointToString converts an EC point to an octet string according to
+	// the encoding specified in Section 2.3.3 of [SECG1] with point
+	// compression on.  This implies ptLen = 2n + 1 = 33.
+	PointToString(Px, Py *big.Int) []byte
+
+	// StringToPoint converts an octet string to an EC point
+	// This function MUST output INVALID if the octet string does not
+	// decode to an EC point.
+	StringToPoint(h []byte) (Px, Py *big.Int, err error)
+
+	// ArbitraryStringToPoint(s) = string_to_point(0x02 || s)
+	// (where 0x02 is a single octet with value 2, 0x02=int_to_string(2, 1)).
+	// The input s is a 32-octet string and the output is either an EC point or "INVALID".
+	ArbitraryStringToPoint(s []byte) (Px, Py *big.Int, err error)
 }

--- a/go/vrf/ecvrf.go
+++ b/go/vrf/ecvrf.go
@@ -60,18 +60,13 @@ type ECVRFParams struct {
 
 // ECVRFAux contains auxiliary functions nessesary for the computation of ECVRF.
 type ECVRFAux interface {
-	// PointToString converts an EC point to an octet string according to
-	// the encoding specified in Section 2.3.3 of [SECG1] with point
-	// compression on.  This implies ptLen = 2n + 1 = 33.
+	// PointToString converts an EC point to an octet string.
 	PointToString(Px, Py *big.Int) []byte
 
-	// StringToPoint converts an octet string to an EC point
-	// This function MUST output INVALID if the octet string does not
-	// decode to an EC point.
+	// StringToPoint converts an octet string to an EC point.
+	// This function MUST output INVALID if the octet string does not decode to an EC point.
 	StringToPoint(h []byte) (Px, Py *big.Int, err error)
 
-	// ArbitraryStringToPoint(s) = string_to_point(0x02 || s)
-	// (where 0x02 is a single octet with value 2, 0x02=int_to_string(2, 1)).
-	// The input s is a 32-octet string and the output is either an EC point or "INVALID".
+	// ArbitraryStringToPoint converts an arbitrary 32 byte string s to an EC point.
 	ArbitraryStringToPoint(s []byte) (Px, Py *big.Int, err error)
 }

--- a/go/vrf/ecvrf_p256_sha256_tai.go
+++ b/go/vrf/ecvrf_p256_sha256_tai.go
@@ -1,0 +1,73 @@
+// Copyright 2020 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vrf
+
+import (
+	"crypto"
+	"crypto/elliptic"
+	"fmt"
+	"math/big"
+
+	_ "crypto/sha256"
+)
+
+var zero big.Int
+
+type (
+	p256SHA256TAISuite struct{ *ECVRFParams }
+	p256SHA256TAIAux   struct{ params *ECVRFParams }
+)
+
+var p256SHA256TAI p256SHA256TAISuite
+
+func initP256SHA256TAI() {
+	// https://tools.ietf.org/html/draft-irtf-cfrg-vrf-06#section-5.5
+	p256SHA256TAI.ECVRFParams = &ECVRFParams{
+		suiteString: []byte{0x01},    // int_to_string(1, 1)
+		ec:          elliptic.P256(), // NIST P-256 elliptic curve, [FIPS-186-4] (Section D.1.2.3).
+		n:           16,              // 2n = 32, Params().BitSize
+		qLen:        32,              // qLen = 32, Params().N.BitLen
+		ptLen:       33,              // Size of encoded EC point
+		cofactor:    1,
+		hash:        crypto.SHA256,
+	}
+	p256SHA256TAI.ECVRFParams.aux = p256SHA256TAIAux{params: p256SHA256TAI.ECVRFParams}
+}
+
+func (s p256SHA256TAISuite) Params() *ECVRFParams {
+	return s.ECVRFParams
+}
+
+func (a p256SHA256TAIAux) PointToString(Px, Py *big.Int) []byte {
+	return secg1EncodeCompressed(a.params.ec, Px, Py)
+}
+
+// String2Point converts an octet string to an EC point according to the
+// encoding specified in Section 2.3.4 of [SECG1].  This function MUST output
+// INVALID if the octet string does not decode to an EC point.
+// http://www.secg.org/sec1-v2.pdf
+func (a p256SHA256TAIAux) StringToPoint(s []byte) (x, y *big.Int, err error) {
+	return secg1Decode(a.params.ec, s)
+}
+
+// ArbitraryString2Point returns string_to_point(0x02 || h_string)
+// Attempts to interpret an arbitrary string as a compressed elliptic code point.
+// The input h is a 32-octet string.  Returns either an EC point or "INVALID".
+func (a p256SHA256TAIAux) ArbitraryStringToPoint(s []byte) (Px, Py *big.Int, err error) {
+	if got, want := len(s), 32; got != want {
+		return nil, nil, fmt.Errorf("len(s): %v, want %v", got, want)
+	}
+	return a.StringToPoint(append([]byte{0x02}, s...))
+}

--- a/go/vrf/ecvrf_p256_sha256_tai.go
+++ b/go/vrf/ecvrf_p256_sha256_tai.go
@@ -33,13 +33,13 @@ var p256SHA256TAI p256SHA256TAISuite
 func initP256SHA256TAI() {
 	// https://tools.ietf.org/html/draft-irtf-cfrg-vrf-06#section-5.5
 	p := &ECVRFParams{
-		suiteString: []byte{0x01},    // int_to_string(1, 1)
-		ec:          elliptic.P256(), // NIST P-256 elliptic curve, [FIPS-186-4] (Section D.1.2.3).
-		n:           16,              // 2n = 32, Params().BitSize
-		qLen:        32,              // qLen = 32, Params().N.BitLen
-		ptLen:       33,              // Size of encoded EC point
-		cofactor:    1,
-		hash:        crypto.SHA256,
+		suite:    0x01,            // int_to_string(1, 1)
+		ec:       elliptic.P256(), // NIST P-256 elliptic curve, [FIPS-186-4] (Section D.1.2.3).
+		fieldLen: 32,              // Params().BitSize / 8 = 2n
+		qLen:     32,              // Params().N.BitLen
+		ptLen:    33,              // Size of encoded EC point
+		cofactor: big.NewInt(1),
+		hash:     crypto.SHA256,
 	}
 	p.aux = p256SHA256TAIAux{params: p}
 	p256SHA256TAI.ECVRFParams = p

--- a/go/vrf/ecvrf_p256_sha256_tai.go
+++ b/go/vrf/ecvrf_p256_sha256_tai.go
@@ -62,7 +62,13 @@ func (a p256SHA256TAIAux) PointToString(Px, Py *big.Int) []byte {
 // INVALID if the octet string does not decode to an EC point.
 // http://www.secg.org/sec1-v2.pdf
 func (a p256SHA256TAIAux) StringToPoint(s []byte) (x, y *big.Int, err error) {
-	return unmarshalCompressed(a.params.ec, s)
+	x, y, err = unmarshalCompressed(a.params.ec, s)
+	if err != nil {
+		return nil, nil, err
+	} else if x == nil {
+		return nil, nil, errInvalidPoint
+	}
+	return x, y, nil
 }
 
 // ArbitraryString2Point returns StringToPoint(0x02 || h).

--- a/go/vrf/ecvrf_p256_sha256_tai.go
+++ b/go/vrf/ecvrf_p256_sha256_tai.go
@@ -50,7 +50,9 @@ func (s p256SHA256TAISuite) Params() *ECVRFParams {
 	return s.ECVRFParams
 }
 
-// PointToString return the point encoded according to Section 2.3.3 of [SECG1] with point compression on.
+// PointToString converts an EC point to an octet string according to
+// the encoding specified in Section 2.3.3 of [SECG1] with point
+// compression on.  This implies ptLen = 2n + 1 = 33.
 func (a p256SHA256TAIAux) PointToString(Px, Py *big.Int) []byte {
 	return marshalCompressed(a.params.ec, Px, Py)
 }
@@ -63,12 +65,12 @@ func (a p256SHA256TAIAux) StringToPoint(s []byte) (x, y *big.Int, err error) {
 	return unmarshalCompressed(a.params.ec, s)
 }
 
-// ArbitraryString2Point returns string_to_point(0x02 || h_string)
+// ArbitraryString2Point returns StringToPoint(0x02 || h).
 // Attempts to interpret an arbitrary string as a compressed elliptic code point.
 // The input h is a 32-octet string.  Returns either an EC point or "INVALID".
-func (a p256SHA256TAIAux) ArbitraryStringToPoint(s []byte) (Px, Py *big.Int, err error) {
-	if got, want := len(s), 32; got != want {
+func (a p256SHA256TAIAux) ArbitraryStringToPoint(h []byte) (Px, Py *big.Int, err error) {
+	if got, want := len(h), 32; got != want {
 		return nil, nil, fmt.Errorf("len(s): %v, want %v", got, want)
 	}
-	return a.StringToPoint(append([]byte{0x02}, s...))
+	return a.StringToPoint(append([]byte{0x02}, h...))
 }


### PR DESCRIPTION
This PR sets out the rough structure of the ECVRF implementation:

- `ECVRFParams` holds private variables that are used to implement the
   elliptic curve VRF suites.
 - `ECVRFAux` is an interface to reference suite specific algorithms
 -  `p256SHA256TAI` is the concrete instance of `ECVRFParams` that
   implements the `P256_SHA256_TAI` VRF.

Depends on #2