### PR TITLE
Simplify ECC CompressedMarshal / Unmarshal

### DIFF
--- a/go/vrf/conversion.go
+++ b/go/vrf/conversion.go
@@ -45,16 +45,15 @@ func i2osp(x *big.Int, rLen uint) []byte {
 	return b.Bytes()[uint(b.Len())-rLen:] // The rightmost rLen bytes.
 }
 
-// SECG1EncodeCompressed converts an EC point to an octet string according to
+// This file implements compressed point unmarshaling.
+// This code will be in go 1.15
+// Code borrowed from: https://github.com/golang/go/pull/35110
+
+// marshalCompressed converts an EC point to an octet string according to
 // the encoding specified in Section 2.3.3 of [SECG1] with point compression
 // on. This implies ptLen = 2n + 1 = 33.
 //
 // SECG1 Section 2.3.3 https://www.secg.org/sec1-v1.99.dif.pdf
-//
-// (Note that certain software implementations do not introduce a separate
-// elliptic curve point type and instead directly treat the EC point as an
-// octet string per above encoding.  When using such an implementation, the
-// point_to_string function can be treated as the identity function.)
 func marshalCompressed(curve elliptic.Curve, x, y *big.Int) []byte {
 	byteLen := (curve.Params().BitSize + 7) >> 3
 	compressed := make([]byte, 1+byteLen)
@@ -65,19 +64,14 @@ func marshalCompressed(curve elliptic.Curve, x, y *big.Int) []byte {
 	return compressed
 }
 
-// This file implements compressed point unmarshaling.  Preferably this
-// functionality would be in a standard library.  Code borrowed from:
-// https://go-review.googlesource.com/#/c/1883/2/src/crypto/elliptic/elliptic.go
+var errInvalidPoint = errors.New("invalid point")
 
-// SECG1Decode decodes a EC point, given as a compressed string.
+// marshalCompressed decodes a EC point, given as a compressed string.
 // If the decoding fails x and y will be nil.
 //
 // http://www.secg.org/sec1-v2.pdf
 // https://tools.ietf.org/html/rfc8032#section-5.1.3
 // Section 4.3.6 of ANSI X9.62.
-
-var errInvalidPoint = errors.New("invalid point")
-
 func unmarshalCompressed(curve elliptic.Curve, data []byte) (x, y *big.Int, err error) {
 	byteLen := (curve.Params().BitSize + 7) >> 3
 	if (data[0] &^ 1) != 2 { // compressed form
@@ -89,13 +83,13 @@ func unmarshalCompressed(curve elliptic.Curve, data []byte) (x, y *big.Int, err 
 
 	// Based on Routine 2.2.4 in NIST Mathematical routines paper
 	x = new(big.Int).SetBytes(data[1:])
-	y2 := y2(curve.Params(), x)
+	y2 := polynomial(curve.Params(), x)
 	y = new(big.Int).ModSqrt(y2, curve.Params().P)
 	if y == nil {
 		return nil, nil, errInvalidPoint // "y^2" is not a square
 	}
 	if !curve.IsOnCurve(x, y) {
-		return nil, nil, errInvalidPoint // sqrt(y2)^2 != y2: invalid point
+		return nil, nil, errInvalidPoint
 	}
 	if y.Bit(0) != uint(data[0]&0x01) {
 		y.Sub(curve.Params().P, y)
@@ -104,18 +98,16 @@ func unmarshalCompressed(curve elliptic.Curve, data []byte) (x, y *big.Int, err 
 	return x, y, nil // valid point: return x,y
 }
 
-// Use the curve equation to calculate y² given x.
-// only applies to curves of the form y² = x³ - 3x + b.
-func y2(curve *elliptic.CurveParams, x *big.Int) *big.Int {
-	// y² = x³ - 3x + b
+// polynomial returns x³ - 3x + b.
+func polynomial(curve *elliptic.CurveParams, x *big.Int) *big.Int {
 	x3 := new(big.Int).Mul(x, x)
 	x3.Mul(x3, x)
 
 	threeX := new(big.Int).Lsh(x, 1)
 	threeX.Add(threeX, x)
+	x3.Sub(x3, threeX)
 
-	y2 := new(big.Int).Sub(x3, threeX)
-	y2.Add(y2, curve.B)
-	y2.Mod(y2, curve.P)
-	return y2
+	x3.Add(x3, curve.B)
+	x3.Mod(x3, curve.P)
+	return x3
 }

--- a/go/vrf/conversion.go
+++ b/go/vrf/conversion.go
@@ -16,8 +16,6 @@ package vrf
 
 import (
 	"bytes"
-	"crypto/elliptic"
-	"errors"
 	"math/big"
 )
 
@@ -43,71 +41,4 @@ func i2osp(x *big.Int, rLen uint) []byte {
 	}
 	b.Write(x.Bytes())
 	return b.Bytes()[uint(b.Len())-rLen:] // The rightmost rLen bytes.
-}
-
-// This file implements compressed point unmarshaling.
-// This code will be in go 1.15
-// Code borrowed from: https://github.com/golang/go/pull/35110
-
-// marshalCompressed converts an EC point to an octet string according to
-// the encoding specified in Section 2.3.3 of [SECG1] with point compression
-// on. This implies ptLen = 2n + 1 = 33.
-//
-// SECG1 Section 2.3.3 https://www.secg.org/sec1-v1.99.dif.pdf
-func marshalCompressed(curve elliptic.Curve, x, y *big.Int) []byte {
-	byteLen := (curve.Params().BitSize + 7) >> 3
-	compressed := make([]byte, 1+byteLen)
-	compressed[0] = 2 // compressed point
-	compressed[0] += byte(y.Bit(0))
-	i := byteLen + 1 - len(x.Bytes())
-	copy(compressed[i:], x.Bytes())
-	return compressed
-}
-
-var errInvalidPoint = errors.New("invalid point")
-
-// marshalCompressed decodes a EC point, given as a compressed string.
-// If the decoding fails x and y will be nil.
-//
-// http://www.secg.org/sec1-v2.pdf
-// https://tools.ietf.org/html/rfc8032#section-5.1.3
-// Section 4.3.6 of ANSI X9.62.
-func unmarshalCompressed(curve elliptic.Curve, data []byte) (x, y *big.Int, err error) {
-	byteLen := (curve.Params().BitSize + 7) >> 3
-	if (data[0] &^ 1) != 2 { // compressed form
-		return nil, nil, errors.New("unrecognized point encoding")
-	}
-	if len(data) != 1+byteLen {
-		return nil, nil, errors.New("invalid length for curve")
-	}
-
-	// Based on Routine 2.2.4 in NIST Mathematical routines paper
-	x = new(big.Int).SetBytes(data[1:])
-	y2 := polynomial(curve.Params(), x)
-	y = new(big.Int).ModSqrt(y2, curve.Params().P)
-	if y == nil {
-		return nil, nil, errInvalidPoint // "y^2" is not a square
-	}
-	if !curve.IsOnCurve(x, y) {
-		return nil, nil, errInvalidPoint
-	}
-	if y.Bit(0) != uint(data[0]&0x01) {
-		y.Sub(curve.Params().P, y)
-	}
-
-	return x, y, nil // valid point: return x,y
-}
-
-// polynomial returns x³ - 3x + b.
-func polynomial(curve *elliptic.CurveParams, x *big.Int) *big.Int {
-	x3 := new(big.Int).Mul(x, x)
-	x3.Mul(x3, x)
-
-	threeX := new(big.Int).Lsh(x, 1)
-	threeX.Add(threeX, x)
-	x3.Sub(x3, threeX)
-
-	x3.Add(x3, curve.B)
-	x3.Mod(x3, curve.P)
-	return x3
 }

--- a/go/vrf/conversion_test.go
+++ b/go/vrf/conversion_test.go
@@ -16,8 +16,6 @@ package vrf
 
 import (
 	"bytes"
-	"crypto/elliptic"
-	"crypto/rand"
 	"fmt"
 	"math/big"
 	"testing"
@@ -48,25 +46,5 @@ func TestI2OSP(t *testing.T) {
 				t.Errorf("I2OSP(%v, %v): %v, want %v", tc.x, tc.xLen, got, tc.want)
 			}
 		})
-	}
-}
-
-func TestCompressedMarshalUnmarshal(t *testing.T) {
-	c := elliptic.P256()
-	_, Ax, Ay, err := elliptic.GenerateKey(c, rand.Reader)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	b := marshalCompressed(c, Ax, Ay)
-	Bx, By, err := unmarshalCompressed(c, b)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if Bx.Cmp(Ax) != 0 {
-		t.Fatalf("Bx: %v, want %v", Bx, Ax)
-	}
-	if By.Cmp(Ay) != 0 {
-		t.Fatalf("By: %v, want %v", By, Ay)
 	}
 }

--- a/go/vrf/conversion_test.go
+++ b/go/vrf/conversion_test.go
@@ -51,7 +51,7 @@ func TestI2OSP(t *testing.T) {
 	}
 }
 
-func TestSEG1EncodeDecode(t *testing.T) {
+func TestCompressedMarshalUnmarshal(t *testing.T) {
 	c := elliptic.P256()
 	_, Ax, Ay, err := elliptic.GenerateKey(c, rand.Reader)
 	if err != nil {

--- a/go/vrf/eccmarshal_pre_go115.go
+++ b/go/vrf/eccmarshal_pre_go115.go
@@ -1,0 +1,88 @@
+// Copyright 2020 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vrf
+
+import (
+	"crypto/elliptic"
+	"errors"
+	"math/big"
+)
+
+// This file implements compressed point unmarshaling.
+// This code will be in go 1.15
+// Code borrowed from: https://github.com/golang/go/pull/35110
+
+// marshalCompressed converts an EC point to an octet string according to
+// the encoding specified in Section 2.3.3 of [SECG1] with point compression
+// on. This implies ptLen = 2n + 1 = 33.
+//
+// SECG1 Section 2.3.3 https://www.secg.org/sec1-v1.99.dif.pdf
+func marshalCompressed(curve elliptic.Curve, x, y *big.Int) []byte {
+	byteLen := (curve.Params().BitSize + 7) >> 3
+	compressed := make([]byte, 1+byteLen)
+	compressed[0] = 2 // compressed point
+	compressed[0] += byte(y.Bit(0))
+	i := byteLen + 1 - len(x.Bytes())
+	copy(compressed[i:], x.Bytes())
+	return compressed
+}
+
+var errInvalidPoint = errors.New("invalid point")
+
+// marshalCompressed decodes a EC point, given as a compressed string.
+// If the decoding fails x and y will be nil.
+//
+// http://www.secg.org/sec1-v2.pdf
+// https://tools.ietf.org/html/rfc8032#section-5.1.3
+// Section 4.3.6 of ANSI X9.62.
+func unmarshalCompressed(curve elliptic.Curve, data []byte) (x, y *big.Int, err error) {
+	byteLen := (curve.Params().BitSize + 7) >> 3
+	if (data[0] &^ 1) != 2 { // compressed form
+		return nil, nil, errors.New("unrecognized point encoding")
+	}
+	if len(data) != 1+byteLen {
+		return nil, nil, errors.New("invalid length for curve")
+	}
+
+	// Based on Routine 2.2.4 in NIST Mathematical routines paper
+	x = new(big.Int).SetBytes(data[1:])
+	y2 := polynomial(curve.Params(), x)
+	y = new(big.Int).ModSqrt(y2, curve.Params().P)
+	if y == nil {
+		return nil, nil, errInvalidPoint // "y^2" is not a square
+	}
+	if !curve.IsOnCurve(x, y) {
+		return nil, nil, errInvalidPoint
+	}
+	if y.Bit(0) != uint(data[0]&0x01) {
+		y.Sub(curve.Params().P, y)
+	}
+
+	return x, y, nil // valid point: return x,y
+}
+
+// polynomial returns x³ - 3x + b.
+func polynomial(curve *elliptic.CurveParams, x *big.Int) *big.Int {
+	x3 := new(big.Int).Mul(x, x)
+	x3.Mul(x3, x)
+
+	threeX := new(big.Int).Lsh(x, 1)
+	threeX.Add(threeX, x)
+	x3.Sub(x3, threeX)
+
+	x3.Add(x3, curve.B)
+	x3.Mod(x3, curve.P)
+	return x3
+}

--- a/go/vrf/eccmarshal_pre_go115.go
+++ b/go/vrf/eccmarshal_pre_go115.go
@@ -12,6 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build !go1.15
+
+// This file implements compressed point unmarshaling.
+// This code will be in go 1.15
+// Code borrowed from: https://github.com/golang/go/pull/35110
+
 package vrf
 
 import (
@@ -19,10 +25,6 @@ import (
 	"errors"
 	"math/big"
 )
-
-// This file implements compressed point unmarshaling.
-// This code will be in go 1.15
-// Code borrowed from: https://github.com/golang/go/pull/35110
 
 // marshalCompressed converts an EC point to an octet string according to
 // the encoding specified in Section 2.3.3 of [SECG1] with point compression

--- a/go/vrf/eccmarshal_pre_go115.go
+++ b/go/vrf/eccmarshal_pre_go115.go
@@ -28,7 +28,7 @@ import (
 
 // marshalCompressed converts an EC point to an octet string according to
 // the encoding specified in Section 2.3.3 of [SECG1] with point compression
-// on. If 2n = ceil(log_2(q) / 8) then ptLen = 2n + 1 = 33.
+// on. If fieldLen = ceil(log_2(q) / 8) then ptLen = fieldLen + 1 = 33.
 //
 // SECG1 Section 2.3.3 https://www.secg.org/sec1-v1.99.dif.pdf
 func marshalCompressed(curve elliptic.Curve, x, y *big.Int) []byte {

--- a/go/vrf/eccmarshal_pre_go115.go
+++ b/go/vrf/eccmarshal_pre_go115.go
@@ -28,7 +28,7 @@ import (
 
 // marshalCompressed converts an EC point to an octet string according to
 // the encoding specified in Section 2.3.3 of [SECG1] with point compression
-// on. This implies ptLen = 2n + 1 = 33.
+// on. If 2n = ceil(log_2(q) / 8) then ptLen = 2n + 1 = 33.
 //
 // SECG1 Section 2.3.3 https://www.secg.org/sec1-v1.99.dif.pdf
 func marshalCompressed(curve elliptic.Curve, x, y *big.Int) []byte {
@@ -43,7 +43,7 @@ func marshalCompressed(curve elliptic.Curve, x, y *big.Int) []byte {
 
 var errInvalidPoint = errors.New("invalid point")
 
-// marshalCompressed decodes a EC point, given as a compressed string.
+// unmarshalCompressed decodes a EC point, given as a compressed string.
 // If the decoding fails x and y will be nil.
 //
 // http://www.secg.org/sec1-v2.pdf

--- a/go/vrf/eccmarshal_pre_go115.go
+++ b/go/vrf/eccmarshal_pre_go115.go
@@ -49,7 +49,7 @@ var errInvalidPoint = errors.New("invalid point")
 // Section 4.3.6 of ANSI X9.62.
 func unmarshalCompressed(curve elliptic.Curve, data []byte) (x, y *big.Int, err error) {
 	byteLen := (curve.Params().BitSize + 7) >> 3
-	if (data[0] &^ 1) != 2 { // compressed form
+	if data[0] != 2 && data[0] != 3 { // compressed form
 		return nil, nil, errors.New("unrecognized point encoding")
 	}
 	if len(data) != 1+byteLen {

--- a/go/vrf/eccmarshal_pre_go115_test.go
+++ b/go/vrf/eccmarshal_pre_go115_test.go
@@ -12,11 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build !go1.15
+
 package vrf
 
 import (
+	"bytes"
 	"crypto/elliptic"
 	"crypto/rand"
+	"crypto/x509/pkix"
+	"encoding/asn1"
+	"encoding/hex"
+	"errors"
+	"fmt"
 	"testing"
 )
 
@@ -37,5 +45,116 @@ func TestCompressedMarshalUnmarshal(t *testing.T) {
 	}
 	if By.Cmp(Ay) != 0 {
 		t.Fatalf("By: %v, want %v", By, Ay)
+	}
+}
+
+func hexd(t testing.TB, h string) []byte {
+	t.Helper()
+	b, err := hex.DecodeString(h)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return b
+}
+
+// https://github.com/google/wycheproof/blob/master/testvectors/ecdh_secp256r1_test.json
+func TestWycheproof(t *testing.T) {
+	curve := elliptic.P256() //secp256r1
+	for _, tc := range []struct {
+		tcID    int
+		comment string
+		public  []byte
+		private []byte
+		shared  []byte
+		result  error
+	}{
+
+		{
+			tcID:    2,
+			comment: "compressed public key",
+			public:  hexd(t, "3039301306072a8648ce3d020106082a8648ce3d0301070322000362d5bd3372af75fe85a040715d0f502428e07046868b0bfdfa61d731afe44f26"),
+			private: hexd(t, "0612465c89a023ab17855b0a6bcebfd3febb53aef84138647b5352e02c10c346"),
+			shared:  hexd(t, "53020d908b0219328b658b525f26780e3ae12bcd952bb25a93bc0895e1714285"),
+			result:  nil,
+		},
+		{
+			tcID:    243,
+			comment: "invalid public key",
+			public:  hexd(t, "3039301306072a8648ce3d020106082a8648ce3d03010703220002fd4bf61763b46581fd9174d623516cf3c81edd40e29ffa2777fb6cb0ae3ce535"),
+			private: hexd(t, "6f953faff3599e6c762d7f4cabfeed092de2add1df1bc5748c6cbb725cf35458"),
+			result:  errInvalidPoint,
+		},
+		{
+			tcID:    244,
+			comment: "public key is a low order point on twist",
+			public:  hexd(t, "3039301306072a8648ce3d020106082a8648ce3d03010703220003efdde3b32872a9effcf3b94cbf73aa7b39f9683ece9121b9852167f4e3da609b"),
+			private: hexd(t, "00d27edf0ff5b6b6b465753e7158370332c153b468a1be087ad0f490bdb99e5f02"),
+			result:  errInvalidPoint,
+		},
+		{
+			tcID:    245,
+			comment: "public key is a low order point on twist",
+			public:  hexd(t, "3039301306072a8648ce3d020106082a8648ce3d03010703220002efdde3b32872a9effcf3b94cbf73aa7b39f9683ece9121b9852167f4e3da609b"),
+			private: hexd(t, "00d27edf0ff5b6b6b465753e7158370332c153b468a1be087ad0f490bdb99e5f03"),
+			result:  errInvalidPoint,
+		},
+		{
+			tcID:    246,
+			comment: "public key is a low order point on twist",
+			public:  hexd(t, "3039301306072a8648ce3d020106082a8648ce3d03010703220002c49524b2adfd8f5f972ef554652836e2efb2d306c6d3b0689234cec93ae73db5"),
+			private: hexd(t, "0095ead84540c2d027aa3130ff1b47888cc1ed67e8dda46156e71ce0991791e835"),
+			result:  errInvalidPoint,
+		},
+		{
+			tcID:    247,
+			comment: "public key is a low order point on twist",
+			public:  hexd(t, "3039301306072a8648ce3d020106082a8648ce3d0301070322000318f9bae7747cd844e98525b7ccd0daf6e1d20a818b2175a9a91e4eae5343bc98"),
+			private: hexd(t, "00a8681ef67fb1f189647d95e8db00c52ceef6d41a85ba0a5bd74c44e8e62c8aa4"),
+			result:  errInvalidPoint,
+		},
+		{
+			tcID:    248,
+			comment: "public key is a low order point on twist",
+			public:  hexd(t, "3039301306072a8648ce3d020106082a8648ce3d0301070322000218f9bae7747cd844e98525b7ccd0daf6e1d20a818b2175a9a91e4eae5343bc98"),
+			private: hexd(t, "00a8681ef67fb1f189647d95e8db00c52ceef6d41a85ba0a5bd74c44e8e62c8aa5"),
+			result:  errInvalidPoint,
+		},
+		{
+			tcID:    249,
+			comment: "public key is a low order point on twist",
+			public:  hexd(t, "3039301306072a8648ce3d020106082a8648ce3d03010703220003c49524b2adfd8f5f972ef554652836e2efb2d306c6d3b0689234cec93ae73db5"),
+			private: hexd(t, "0095ead84540c2d027aa3130ff1b47888cc1ed67e8dda46156e71ce0991791e834"),
+			result:  errInvalidPoint,
+		},
+	} {
+		t.Run(fmt.Sprintf("%d", tc.tcID), func(t *testing.T) {
+			t.Logf("comment: %s", tc.comment)
+
+			// parse public key as x509 ASN.1
+			var pki struct {
+				Raw       asn1.RawContent
+				Algorithm pkix.AlgorithmIdentifier
+				PublicKey asn1.BitString
+			}
+			if _, err := asn1.Unmarshal(tc.public, &pki); err != nil {
+				t.Fatal(err)
+			}
+			asn1Data := pki.PublicKey.RightAlign()
+			t.Logf("public key: %x", asn1Data)
+
+			x, y, err := unmarshalCompressed(curve, asn1Data)
+			if !errors.Is(err, tc.result) {
+				t.Errorf("got err %q, want %q", err, tc.result)
+			}
+			if err != nil {
+				return
+			}
+
+			// Compute ECDH shared secret to complete the test
+			Sx, _ := curve.ScalarMult(x, y, tc.private)
+			if got := Sx.Bytes(); !bytes.Equal(got, tc.shared) {
+				t.Errorf("shared secret: %x, want %x", got, tc.shared)
+			}
+		})
 	}
 }

--- a/go/vrf/eccmarshal_pre_go115_test.go
+++ b/go/vrf/eccmarshal_pre_go115_test.go
@@ -1,0 +1,41 @@
+// Copyright 2020 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vrf
+
+import (
+	"crypto/elliptic"
+	"crypto/rand"
+	"testing"
+)
+
+func TestCompressedMarshalUnmarshal(t *testing.T) {
+	c := elliptic.P256()
+	_, Ax, Ay, err := elliptic.GenerateKey(c, rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	b := marshalCompressed(c, Ax, Ay)
+	Bx, By, err := unmarshalCompressed(c, b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if Bx.Cmp(Ax) != 0 {
+		t.Fatalf("Bx: %v, want %v", Bx, Ax)
+	}
+	if By.Cmp(Ay) != 0 {
+		t.Fatalf("By: %v, want %v", By, Ay)
+	}
+}


### PR DESCRIPTION
Inspired by https://github.com/golang/go/pull/35110

CompessedMarshal/Unmarshal will be available in Go 1.15, but it's not released yet. 