### PR TITLE
HashToCurveTryAndIncrement

### DIFF
--- a/go/vrf/ecvrf.go
+++ b/go/vrf/ecvrf.go
@@ -20,6 +20,10 @@ import (
 	"math/big"
 )
 
+func init() {
+	initP256SHA256TAI()
+}
+
 // PublicKey holds a public VRF key.
 type PublicKey struct {
 	elliptic.Curve

--- a/go/vrf/ecvrf.go
+++ b/go/vrf/ecvrf.go
@@ -73,4 +73,7 @@ type ECVRFAux interface {
 
 	// ArbitraryStringToPoint converts an arbitrary 32 byte string s to an EC point.
 	ArbitraryStringToPoint(s []byte) (Px, Py *big.Int, err error)
+
+	// HashToCurve is a collision resistant hash of VRF input alpha to H, an EC point in G.
+	HashToCurve(Y *PublicKey, alpha []byte) (Hx, Hy *big.Int)
 }

--- a/go/vrf/ecvrf_p256_sha256_tai.go
+++ b/go/vrf/ecvrf_p256_sha256_tai.go
@@ -80,3 +80,64 @@ func (a p256SHA256TAIAux) ArbitraryStringToPoint(h []byte) (Px, Py *big.Int, err
 	}
 	return a.StringToPoint(append([]byte{0x02}, h...))
 }
+
+var zero big.Int
+
+// HashToCurve implements the HashToCurveTryAndIncrement algorithm from section 5.4.1.1.
+//
+// The running time of this algorithm depends on alpha. For the ciphersuites
+// specified in Section 5.5, this algorithm is expected to find a valid curve
+// point after approximately two attempts (i.e., when ctr=1) on average.
+//
+// However, because the running time of algorithm depends on alpha, this
+// algorithm SHOULD be avoided in applications where it is important that the
+// VRF input alpha remain secret.
+//
+// Inputs:
+// - `suite` - a single octet specifying ECVRF ciphersuite.
+// - `pub`   - public key, an EC point
+// - `alpha` - value to be hashed, an octet string
+// Output:
+// - `H` - hashed value, a finite EC point in G
+// - `ctr` - integer, number of suite byte, attempts to find a valid curve point
+func (a p256SHA256TAIAux) HashToCurve(pub *PublicKey, alpha []byte) (Hx, Hy *big.Int) {
+	Hx, Hy, _ = a.hashToCurve(pub, alpha)
+	return
+}
+
+func (a p256SHA256TAIAux) hashToCurve(pub *PublicKey, alpha []byte) (Hx, Hy *big.Int, ctr byte) {
+	// 1.  ctr = 0
+	ctr = 0
+	// 2.  PK_string = point_to_string(Y)
+	pk := a.PointToString(pub.X, pub.Y)
+
+	// 3.  one_string = 0x01 = int_to_string(1, 1), a single octet with value 1
+	one := []byte{0x01}
+
+	// 4.  H = "INVALID"
+	h := a.params.hash.New()
+
+	// 5.  While H is "INVALID" or H is EC point at infinity:
+	var err error
+	for Hx == nil || err != nil || (zero.Cmp(Hx) == 0 && zero.Cmp(Hy) == 0) {
+		// A.  ctr_string = int_to_string(ctr, 1)
+		ctrString := []byte{ctr}
+		// B.  hash_string = Hash(suite_string || one_string ||
+		//     PK_string || alpha_string || ctr_string)
+		h.Reset()
+		h.Write([]byte{a.params.suite})
+		h.Write(one)
+		h.Write(pk)
+		h.Write(alpha)
+		h.Write(ctrString)
+		hashString := h.Sum(nil)
+		// C.  H = arbitrary_string_to_point(hash_string)
+		Hx, Hy, err = a.ArbitraryStringToPoint(hashString)
+		// D.  If H is not "INVALID" and cofactor > 1, set H = cofactor * H
+		// Cofactor for prime ordered curves is 1.
+		ctr++
+	}
+	ctr--
+	// 6.  Output H
+	return Hx, Hy, ctr
+}

--- a/go/vrf/ecvrf_p256_sha256_tai.go
+++ b/go/vrf/ecvrf_p256_sha256_tai.go
@@ -18,6 +18,7 @@ import (
 	"crypto"
 	"crypto/elliptic"
 	"fmt"
+	"math"
 	"math/big"
 
 	_ "crypto/sha256"
@@ -106,7 +107,7 @@ func (a p256SHA256TAIAux) HashToCurve(pub *PublicKey, alpha []byte) (Hx, Hy *big
 	return
 }
 
-func (a p256SHA256TAIAux) hashToCurve(pub *PublicKey, alpha []byte) (Hx, Hy *big.Int, ctr byte) {
+func (a p256SHA256TAIAux) hashToCurve(pub *PublicKey, alpha []byte) (Hx, Hy *big.Int, ctr uint8) {
 	// 1.  ctr = 0
 	ctr = 0
 	// 2.  PK_string = point_to_string(pub)
@@ -138,6 +139,9 @@ func (a p256SHA256TAIAux) hashToCurve(pub *PublicKey, alpha []byte) (Hx, Hy *big
 		// Cofactor for prime ordered curves is 1.
 		if err == nil && a.params.cofactor.Cmp(one) > 0 {
 			Hx, Hy = a.params.ec.ScalarMult(Hx, Hy, a.params.cofactor.Bytes())
+		}
+		if ctr == math.MaxUint8 {
+			panic("HashToCurveTAI ctr overflow")
 		}
 		ctr++
 	}

--- a/go/vrf/ecvrf_p256_sha256_tai_test.go
+++ b/go/vrf/ecvrf_p256_sha256_tai_test.go
@@ -42,6 +42,7 @@ func TestECVRF_P256_SHA256_TAI(t *testing.T) {
 		pi      []byte
 		beta    []byte
 	}{
+		// Test vectors: https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-vrf-06#appendix-A.1
 		{
 			SK:      h2b(t, "c9afa9d845ba75166b5c215767b1d6934e50c3db36e89b127b8a622b120f6721"),
 			PK:      h2b(t, "0360fed4ba255a9d31c961eb74c6356d68c049b8923b61fa6ce669622e60f29fb6"),

--- a/go/vrf/ecvrf_p256_sha256_tai_test.go
+++ b/go/vrf/ecvrf_p256_sha256_tai_test.go
@@ -1,0 +1,108 @@
+// Copyright 2020 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vrf
+
+import (
+	"bytes"
+	"encoding/hex"
+	"fmt"
+	"testing"
+)
+
+func h2b(t testing.TB, h string) []byte {
+	b, err := hex.DecodeString(h)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return b
+}
+
+func TestECVRF_P256_SHA256_TAI(t *testing.T) {
+	for i, tc := range []struct {
+		SK      []byte
+		PK      []byte
+		alpha   []byte
+		wantCtr byte
+		H       []byte
+		k       []byte
+		U       []byte
+		V       []byte
+		pi      []byte
+		beta    []byte
+	}{
+		{
+			SK:      h2b(t, "c9afa9d845ba75166b5c215767b1d6934e50c3db36e89b127b8a622b120f6721"),
+			PK:      h2b(t, "0360fed4ba255a9d31c961eb74c6356d68c049b8923b61fa6ce669622e60f29fb6"),
+			alpha:   []byte("sample"), // 0x73616d706c65, // (ASCII "sample")
+			wantCtr: 0,                // try_and_increment succeded on ctr = 0
+			H:       h2b(t, "02e2e1ab1b9f5a8a68fa4aad597e7493095648d3473b213bba120fe42d1a595f3e"),
+			/*
+			   k = b7de5757b28c349da738409dfba70763ace31a6b15be8216991715fbc833e5fa
+			   U = k*B = 030286d82c95d54feef4d39c000f8659a5ce00a5f71d3a888bd1b8e8bf07449a50
+			   V = k*H = 03e4258b4a5f772ed29830050712fa09ea8840715493f78e5aaaf7b27248efc216
+			   pi = 029bdca4cc39e57d97e2f42f88bcf0ecb1120fb67eb408a856050dbfbcbf57c5
+			   24347fc46ccd87843ec0a9fdc090a407c6fbae8ac1480e240c58854897eabbc3a7bb6
+			   1b201059f89186e7175af796d65e7
+			   beta : 59ca3801ad3e981a88e36880a3aee1df38a0472d5be52d6e39663ea0314e594c,
+			*/
+		},
+		{
+			SK:      h2b(t, "c9afa9d845ba75166b5c215767b1d6934e50c3db36e89b127b8a622b120f6721"),
+			PK:      h2b(t, "0360fed4ba255a9d31c961eb74c6356d68c049b8923b61fa6ce669622e60f29fb6"),
+			alpha:   []byte("test"), // 74657374
+			wantCtr: 0,              // succeded on ctr = 0
+			H:       h2b(t, "02ca565721155f9fd596f1c529c7af15dad671ab30c76713889e3d45b767ff6433"),
+			/*
+			   k = c3c4f385523b814e1794f22ad1679c952e83bff78583c85eb5c2f6ea6eee2e7d
+			   U = k*B = 034b3793d1088500ec3cccdea079beb0e2c7cdf4dccef1bbda379cc06e084f09d0
+			   V = k*H = 02427cdb19aa5dd645e153d6bd8c0d81a658deee37b203edfd461953f301c4f868
+			   pi = 03873a1cce2ca197e466cc116bca7b1156fff599be67ea40b17256c4f34ba254
+			   9c94ffd2b31588b5fe034fd92c87de5b520b12084da6c4ab63080a7c5467094a1ee84
+			   b80b59aca54bba2e2baa0d108191b
+			   beta = dc85c20f95100626eddc90173ab58d5e4f837bb047fb2f72e9a408feae5bc6c1
+			*/
+		},
+		{
+			SK:      h2b(t, "2ca1411a41b17b24cc8c3b089cfd033f1920202a6c0de8abb97df1498d50d2c8"),
+			PK:      h2b(t, "03596375e6ce57e0f20294fc46bdfcfd19a39f8161b58695b3ec5b3d16427c274d"),
+			alpha:   []byte("Example of ECDSA with ansip256r1 and SHA-256"),
+			wantCtr: 1, // try_and_increment succeded on ctr = 1
+			H:       h2b(t, "02141e41d4d55802b0e3adaba114c81137d95fd3869b6b385d4487b1130126648d"),
+			/*
+			   k = 6ac8f1efa102bdcdcc8db99b755d39bc995491e3f9dea076add1905a92779610
+			   U = k*B = 034bf7bd3638ef06461c6ec0cfaef7e58bfdaa971d7e36125811e629e1a1e77c8a
+			   V = k*H = 03b8b33a134759eb8c9094fb981c9590aa53fd13d35042575067a7bd7c5bc6287b
+			   pi = 02abe3ce3b3aa2ab3c6855a7e729517ebfab6901c2fd228f6fa066f15ebc9b9d
+			   415a680736f7c33f6c796e367f7b2f467026495907affb124be9711cf0e2d05722d3a
+			   33e11d0c5bf932b8f0c5ed1981b64
+			   beta = e880bde34ac5263b2ce5c04626870be2cbff1edcdadabd7d4cb7cbc696467168
+			*/
+		},
+	} {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			v := p256SHA256TAI
+			aux := v.aux.(p256SHA256TAIAux)
+			sk := NewKey(v.Params().ec, tc.SK)
+
+			Hx, Hy, ctr := aux.hashToCurve(sk.Public(), tc.alpha)
+			if ctr != tc.wantCtr {
+				t.Fatalf("HashToCurve: ctr: %v, want %v", ctr, tc.wantCtr)
+			}
+			if got := aux.PointToString(Hx, Hy); !bytes.Equal(got, tc.H) {
+				t.Fatalf("H: %x, want %x", got, tc.H)
+			}
+		})
+	}
+}


### PR DESCRIPTION
[Section 5.4.1](https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-vrf-06#section-5.4.1)

The `ECVRF_hash_to_curve` algorithm takes in the VRF input alpha and converts
it to H, an EC point in G.  This algorithm is the only place the VRF input
alpha is used in for proving and verfying.

The `ECVRF_hash_to_curve_try_and_increment` algorithm implements
`ECVRF_hash_to_curve` in a simple and generic way that works for any elliptic
curve.

The running time of this algorithm depends on alpha_string.  This algorithm is
expected to find a valid curve point after approximately two attempts (i.e.,
when ctr=1) on average.

However, because the running time of algorithm depends on alpha_string, this
algorithm SHOULD be avoided in applications where it is important that the VRF
input alpha remain secret.