### PR TITLE
GenerateNonceRFC6979

### DIFF
--- a/go/vrf/conversion.go
+++ b/go/vrf/conversion.go
@@ -46,21 +46,23 @@ func i2osp(x *big.Int, rLen uint) []byte {
 }
 
 // bits2int takes as input a sequence of blen bits and outputs a non-negative
-// integer that is less than 2^qlen.
+// integer that is less than 2^qlen.  bits2int operates on byte boundaries,
+// meaning blen = 8*len(b). Returns the integer value of the qlen leftmost bits.
 // https://tools.ietf.org/html/rfc6979#section-2.3.2
 func bits2int(b []byte, qlen int) *big.Int {
 	blen := len(b) * 8
 	v := new(big.Int).SetBytes(b)
 	// 1.  The sequence is first truncated or expanded to length qlen:
 	if qlen < blen {
-		// if qlen < blen, then the qlen leftmost bits are kept, and
+		// Truncate:
+		// If qlen < blen, then the qlen leftmost bits are kept, and
 		// subsequent bits are discarded;
 		v = new(big.Int).Rsh(v, uint(blen-qlen))
-	} else {
-		// otherwise, qlen-blen bits (of value zero) are added to the
-		// left of the sequence (i.e., before the input bits in the
-		// sequence order).
 	}
+	// Expand: fill the high order bits with zeros. Happens by default.
+	// otherwise, qlen-blen bits (of value zero) are added to the
+	// left of the sequence (i.e., before the input bits in the
+	// sequence order).
 
 	// 2.  The resulting sequence is then converted to an integer value
 	//     using the big-endian convention: if input bits are called b_0

--- a/go/vrf/conversion.go
+++ b/go/vrf/conversion.go
@@ -71,6 +71,35 @@ func bits2int(b []byte, qlen int) *big.Int {
 	return v
 }
 
+// int2octets returns x as a sequence of rlen bits.
+// int2octets deviates from x.Bytes() by returning a byte slice of exact length.
+//
+// x is an integer value less than q (and, in particular, a value that has been
+// taken modulo q) as sequence of rlen bits, where rlen = 8*ceil(qlen/8).  This
+// is the sequence of bits obtained by big-endian encoding.  In other words,
+// the sequence bits x_i (for i ranging from 0 to rlen-1) are such that:
+//
+//   x = x_0*2^(rlen-1) + x_1*2^(rlen-2) + ... + x_(rlen-1)
+//
+// Since rlen is a multiple of 8 (the smallest multiple of 8 that is not
+// smaller than qlen), then the resulting sequence of bits is also a sequence
+// of octets, hence the name int2octets.
+//
+// https://tools.ietf.org/html/rfc6979#section-2.3.3
+func int2octets(x *big.Int, rlen int) []byte {
+	b := x.Bytes()
+	blen := len(b) * 8
+	if blen < rlen {
+		// left pad with rlen - blen bits
+		b = append(make([]byte, (rlen-blen)/8), b...)
+	}
+	if blen > rlen {
+		// truncate to blen bits
+		b = b[:rlen/8]
+	}
+	return b
+}
+
 // SECG1EncodeCompressed converts an EC point to an octet string according to
 // the encoding specified in Section 2.3.3 of [SECG1] with point compression
 // on. This implies ptLen = 2n + 1 = 33.

--- a/go/vrf/conversion.go
+++ b/go/vrf/conversion.go
@@ -100,6 +100,23 @@ func int2octets(x *big.Int, rlen int) []byte {
 	return b
 }
 
+//  bits2octets takes as input a sequence of blen bits and outputs a sequence of rlen bits.
+//
+// https://datatracker.ietf.org/doc/html/rfc6979#section-2.3.4
+func bits2octets(b []byte, rlen int, q *big.Int) []byte {
+	//  1.  The input sequence b is converted into an integer value z1 through the bits2int transform:
+	z1 := bits2int(b, q.BitLen())
+	//  2.  z1 is reduced modulo q, yielding z2 (an integer between 0 and q-1, inclusive):
+	z2 := new(big.Int).Mod(z1, q)
+
+	// Note that since z1 is less than 2^qlen, that modular reduction
+	// can be implemented with a simple conditional subtraction:
+	// z2 = z1-q if that value is non-negative; otherwise, z2 = z1.
+
+	// 3.  z2 is transformed into a sequence of octets (a sequence of rlen bits) by applying int2octets.
+	return int2octets(z2, rlen)
+}
+
 // SECG1EncodeCompressed converts an EC point to an octet string according to
 // the encoding specified in Section 2.3.3 of [SECG1] with point compression
 // on. This implies ptLen = 2n + 1 = 33.

--- a/go/vrf/conversion.go
+++ b/go/vrf/conversion.go
@@ -45,6 +45,30 @@ func i2osp(x *big.Int, rLen uint) []byte {
 	return b.Bytes()[uint(b.Len())-rLen:] // The rightmost rLen bytes.
 }
 
+// bits2int takes as input a sequence of blen bits and outputs a non-negative
+// integer that is less than 2^qlen.
+// https://tools.ietf.org/html/rfc6979#section-2.3.2
+func bits2int(b []byte, qlen int) *big.Int {
+	blen := len(b) * 8
+	v := new(big.Int).SetBytes(b)
+	// 1.  The sequence is first truncated or expanded to length qlen:
+	if qlen < blen {
+		// if qlen < blen, then the qlen leftmost bits are kept, and
+		// subsequent bits are discarded;
+		v = new(big.Int).Rsh(v, uint(blen-qlen))
+	} else {
+		// otherwise, qlen-blen bits (of value zero) are added to the
+		// left of the sequence (i.e., before the input bits in the
+		// sequence order).
+	}
+
+	// 2.  The resulting sequence is then converted to an integer value
+	//     using the big-endian convention: if input bits are called b_0
+	//     (leftmost) to b_(qlen-1) (rightmost), then the resulting value
+	//     is: b_0*2^(qlen-1) + b_1*2^(qlen-2) + ... + b_(qlen-1)*2^0
+	return v
+}
+
 // SECG1EncodeCompressed converts an EC point to an octet string according to
 // the encoding specified in Section 2.3.3 of [SECG1] with point compression
 // on. This implies ptLen = 2n + 1 = 33.

--- a/go/vrf/conversion.go
+++ b/go/vrf/conversion.go
@@ -86,7 +86,8 @@ func bits2int(b []byte, qlen int) *big.Int {
 // of octets, hence the name int2octets.
 //
 // https://tools.ietf.org/html/rfc6979#section-2.3.3
-func int2octets(x *big.Int, rlen int) []byte {
+func int2octets(x *big.Int, qlen int) []byte {
+	rlen := 8 * ((qlen + 7) >> 3) // rlen = 8*ceil(qlen/8)
 	b := x.Bytes()
 	blen := len(b) * 8
 	if blen < rlen {
@@ -100,10 +101,11 @@ func int2octets(x *big.Int, rlen int) []byte {
 	return b
 }
 
-//  bits2octets takes as input a sequence of blen bits and outputs a sequence of rlen bits.
+//  bits2octets takes as input a sequence of blen bits and outputs a sequence
+//  of rlen = 8*ceil(qlen/8) bits.
 //
 // https://datatracker.ietf.org/doc/html/rfc6979#section-2.3.4
-func bits2octets(b []byte, rlen int, q *big.Int) []byte {
+func bits2octets(b []byte, q *big.Int) []byte {
 	//  1.  The input sequence b is converted into an integer value z1 through the bits2int transform:
 	z1 := bits2int(b, q.BitLen())
 	//  2.  z1 is reduced modulo q, yielding z2 (an integer between 0 and q-1, inclusive):
@@ -114,7 +116,7 @@ func bits2octets(b []byte, rlen int, q *big.Int) []byte {
 	// z2 = z1-q if that value is non-negative; otherwise, z2 = z1.
 
 	// 3.  z2 is transformed into a sequence of octets (a sequence of rlen bits) by applying int2octets.
-	return int2octets(z2, rlen)
+	return int2octets(z2, q.BitLen())
 }
 
 // SECG1EncodeCompressed converts an EC point to an octet string according to

--- a/go/vrf/conversion_test.go
+++ b/go/vrf/conversion_test.go
@@ -72,15 +72,15 @@ func Testbits2int(t *testing.T) {
 func Testint2octets(t *testing.T) {
 	for _, tc := range []struct {
 		x    *big.Int
-		rlen int
+		qlen int
 		want []byte
 	}{
-		{x: big.NewInt(1), rlen: 0, want: []byte{0x00}},
-		{x: big.NewInt(1), rlen: 8, want: []byte{0x01}},
-		{x: big.NewInt(1), rlen: 16, want: []byte{0x00, 0x01}},
+		{x: big.NewInt(1), qlen: 0, want: []byte{0x00}},
+		{x: big.NewInt(1), qlen: 8, want: []byte{0x01}},
+		{x: big.NewInt(1), qlen: 16, want: []byte{0x00, 0x01}},
 	} {
-		if got := int2octets(tc.x, tc.rlen); !bytes.Equal(got, tc.want) {
-			t.Errorf("int2octets(%v, %d):0x%x, want 0x%x", tc.x, tc.rlen, got, tc.want)
+		if got := int2octets(tc.x, tc.qlen); !bytes.Equal(got, tc.want) {
+			t.Errorf("int2octets(%v, %d):0x%x, want 0x%x", tc.x, tc.qlen, got, tc.want)
 		}
 	}
 }

--- a/go/vrf/conversion_test.go
+++ b/go/vrf/conversion_test.go
@@ -69,6 +69,22 @@ func Testbits2int(t *testing.T) {
 	}
 }
 
+func Testint2octets(t *testing.T) {
+	for _, tc := range []struct {
+		x    *big.Int
+		rlen int
+		want []byte
+	}{
+		{x: big.NewInt(1), rlen: 0, want: []byte{0x00}},
+		{x: big.NewInt(1), rlen: 8, want: []byte{0x01}},
+		{x: big.NewInt(1), rlen: 16, want: []byte{0x00, 0x01}},
+	} {
+		if got := int2octets(tc.x, tc.rlen); !bytes.Equal(got, tc.want) {
+			t.Errorf("int2octets(%v, %d):0x%x, want 0x%x", tc.x, tc.rlen, got, tc.want)
+		}
+	}
+}
+
 func TestSEG1EncodeDecode(t *testing.T) {
 	c := elliptic.P256()
 	_, Ax, Ay, err := elliptic.GenerateKey(c, rand.Reader)

--- a/go/vrf/conversion_test.go
+++ b/go/vrf/conversion_test.go
@@ -51,6 +51,24 @@ func TestI2OSP(t *testing.T) {
 	}
 }
 
+func Testbits2int(t *testing.T) {
+	for _, tc := range []struct {
+		b    []byte
+		qlen int
+		want *big.Int
+	}{
+		{b: []byte{0x01}, qlen: 1, want: big.NewInt(0)},
+		{b: []byte{0x80}, qlen: 1, want: big.NewInt(1)}, // 1 leftmost bit is kept.
+		{b: []byte{0x01}, qlen: 8, want: big.NewInt(1)},
+		{b: []byte{0x01, 0x00}, qlen: 8, want: big.NewInt(1)}, // 8 leftmost bits are kept.
+		{b: []byte{0x01, 0x00}, qlen: 16, want: big.NewInt(256)},
+	} {
+		if got := bits2int(tc.b, tc.qlen); got.Cmp(tc.want) != 0 {
+			t.Errorf("bits2int(0x%x, %v): %v, want %v", tc.b, tc.qlen, got, tc.want)
+		}
+	}
+}
+
 func TestSEG1EncodeDecode(t *testing.T) {
 	c := elliptic.P256()
 	_, Ax, Ay, err := elliptic.GenerateKey(c, rand.Reader)

--- a/go/vrf/conversion_test.go
+++ b/go/vrf/conversion_test.go
@@ -51,7 +51,7 @@ func TestI2OSP(t *testing.T) {
 	}
 }
 
-func Testbits2int(t *testing.T) {
+func TestBits2int(t *testing.T) {
 	for _, tc := range []struct {
 		b    []byte
 		qlen int
@@ -69,13 +69,13 @@ func Testbits2int(t *testing.T) {
 	}
 }
 
-func Testint2octets(t *testing.T) {
+func TestInt2octets(t *testing.T) {
 	for _, tc := range []struct {
 		x    *big.Int
 		qlen int
 		want []byte
 	}{
-		{x: big.NewInt(1), qlen: 0, want: []byte{0x00}},
+		{x: big.NewInt(1), qlen: 0, want: []byte{}},
 		{x: big.NewInt(1), qlen: 8, want: []byte{0x01}},
 		{x: big.NewInt(1), qlen: 16, want: []byte{0x00, 0x01}},
 	} {

--- a/go/vrf/ecvrf.go
+++ b/go/vrf/ecvrf.go
@@ -69,4 +69,7 @@ type ECVRFAux interface {
 
 	// ArbitraryStringToPoint converts an arbitrary 32 byte string s to an EC point.
 	ArbitraryStringToPoint(s []byte) (Px, Py *big.Int, err error)
+
+	// GenerateNonoce generates the nonce value k in a deterministic, pseudorandom fashion.
+	GenerateNonce(sk *PrivateKey, h []byte) (k *big.Int)
 }

--- a/go/vrf/ecvrf_p256_sha256_tai.go
+++ b/go/vrf/ecvrf_p256_sha256_tai.go
@@ -139,8 +139,8 @@ func (a p256SHA256TAIAux) GenerateNonce(sk *PrivateKey, h []byte) (k *big.Int) {
 	hm := hmac.New(hash.New, K)
 	hm.Write(V)
 	hm.Write([]byte{0x00})
-	hm.Write(x.Bytes()) // int2octets
-	hm.Write(h1Digest)  // bits2octets
+	hm.Write(int2octets(x, qlen))
+	hm.Write(bits2octets(h1Digest, q))
 	K = hm.Sum(nil)
 
 	// e.  Set:
@@ -155,8 +155,8 @@ func (a p256SHA256TAIAux) GenerateNonce(sk *PrivateKey, h []byte) (k *big.Int) {
 	hm = hmac.New(hash.New, K)
 	hm.Write(V)
 	hm.Write([]byte{0x01})
-	hm.Write(x.Bytes())
-	hm.Write(h1Digest)
+	hm.Write(int2octets(x, qlen))
+	hm.Write(bits2octets(h1Digest, q))
 	K = hm.Sum(nil)
 
 	// g.  Set:

--- a/go/vrf/ecvrf_p256_sha256_tai.go
+++ b/go/vrf/ecvrf_p256_sha256_tai.go
@@ -15,8 +15,10 @@
 package vrf
 
 import (
+	"bytes"
 	"crypto"
 	"crypto/elliptic"
+	"crypto/hmac"
 	"fmt"
 	"math/big"
 
@@ -79,4 +81,125 @@ func (a p256SHA256TAIAux) ArbitraryStringToPoint(h []byte) (Px, Py *big.Int, err
 		return nil, nil, fmt.Errorf("len(s): %v, want %v", got, want)
 	}
 	return a.StringToPoint(append([]byte{0x02}, h...))
+}
+
+// GenerateNonce implements RFC 6979 section 3.2
+//    Input:
+//       sk - an ECVRF secret key
+//       h  - an octet string
+//
+//    Output:
+//       k - an integer between 1 and q-1
+func (a p256SHA256TAIAux) GenerateNonce(sk *PrivateKey, h []byte) (k *big.Int) {
+	m := h    // Input m is set equal to h_string
+	x := sk.d // The secret key x is set equal to the VRF secret scalar x
+
+	// The "suitable for DSA or ECDSA" check in step h.3 is omitted
+	// The hash function H is Hash and its output length hlen is set as hLen*8
+	hash := a.params.hash
+
+	// The prime q is the same as in this specification
+	q := sk.Params().N
+
+	// qlen is the binary length of q, i.e., the smallest integer such that 2^qlen > q
+	// All the other values and primitives as defined in [RFC6979]
+	//
+	// N, also known as q, is the order of the base point, which generates subgroup Gi.
+	qlen := q.BitLen()
+
+	//
+	// RFC 6979 section 3.2
+	//
+
+	// a.  Process m through the hash function H, yielding: h1 = H(m)
+	h1 := hash.New()
+	h1.Write(m) // (h1 is a sequence of hlen bits).
+	h1Digest := h1.Sum(nil)
+
+	// b.  Set: V = 0x01 0x01 0x01 ... 0x01
+	//     such that the length of V, in bits, is equal to 8*ceil(hlen/8).
+	//     For instance, on an octet-based system, if H is SHA-256, then V
+	//     is set to a sequence of 32 octets of value 1.
+	V := bytes.Repeat([]byte{0x01}, hash.Size())
+
+	// c.  Set: K = 0x00 0x00 0x00 ... 0x00
+	//     such that the length of K, in bits, is equal to 8*ceil(hlen/8).
+	K := make([]byte, hash.Size())
+
+	// d.  Set: K = HMAC_K(V || 0x00 || int2octets(x) || bits2octets(h1))
+	//     where '||' denotes concatenation.  In other words, we compute
+	//     HMAC with key K, over the concatenation of the following, in
+	//     order: the current value of V, a sequence of eight bits of value
+	//     0, the encoding of the (EC)DSA private key x, and the hashed
+	//     message (possibly truncated and extended as specified by the
+	//     bits2octets transform).  The HMAC result is the new value of K.
+	//     Note that the private key x is in the [1, q-1] range, hence a
+	//     proper input for int2octets, yielding rlen bits of output, i.e.,
+	//     an integral number of octets (rlen is a multiple of 8).
+	hm := hmac.New(hash.New, K)
+	hm.Write(V)
+	hm.Write([]byte{0x00})
+	hm.Write(x.Bytes()) // int2octets
+	hm.Write(h1Digest)  // bits2octets
+	K = hm.Sum(nil)
+
+	// e.  Set:
+	//     V = HMAC_K(V)
+	vm := hmac.New(hash.New, K)
+	vm.Write(V)
+	V = vm.Sum(nil)
+
+	// f.  Set:
+	//     K = HMAC_K(V || 0x01 || int2octets(x) || bits2octets(h1))
+	//     Note that the "internal octet" is 0x01 this time.
+	hm = hmac.New(hash.New, K)
+	hm.Write(V)
+	hm.Write([]byte{0x01})
+	hm.Write(x.Bytes())
+	hm.Write(h1Digest)
+	K = hm.Sum(nil)
+
+	// g.  Set:
+	//     V = HMAC_K(V)
+	vm = hmac.New(hash.New, K)
+	vm.Write(V)
+	V = vm.Sum(nil)
+
+	// h.  Apply the following algorithm until a proper value is found for k:
+	for {
+		// 1.  Set T to the empty sequence.  The length of T (in bits) is
+		//     denoted tlen; thus, at that point, tlen = 0.
+		T := make([]byte, 0, qlen/8)
+		//  2.  While tlen < qlen, do the following:
+		for len(T) < qlen/8 {
+			//         V = HMAC_K(V)
+			vm = hmac.New(hash.New, K)
+			vm.Write(V)
+			V = vm.Sum(nil)
+			//         T = T || V
+			T = append(T, V...)
+		}
+		//  3.  Compute: k = bits2int(T)
+		k := bits2int(T, qlen)
+		one := big.NewInt(1)
+		// If that value of k is within the [1,q-1] range, then the generation of k is finished.
+		// (The "suitable for DSA or ECDSA" check in step h.3 is omitted.)
+		if k.Cmp(one) >= 0 && k.Cmp(q) < 0 {
+			return k
+		}
+
+		// Otherwise, compute:
+		//    K = HMAC_K(V || 0x00)
+		km := hmac.New(hash.New, K)
+		km.Write(V)
+		km.Write([]byte{0x00})
+		K = km.Sum(nil)
+
+		//    V = HMAC_K(V)
+		km = hmac.New(hash.New, K)
+		km.Write(V)
+		V = km.Sum(nil)
+
+		// and loop (try to generate a new T, and so on).
+	}
 }

--- a/go/vrf/ecvrf_p256_sha256_tai_test.go
+++ b/go/vrf/ecvrf_p256_sha256_tai_test.go
@@ -1,0 +1,53 @@
+// Copyright 2020 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vrf
+
+import (
+	"bytes"
+	"crypto/elliptic"
+	"encoding/hex"
+	"math/big"
+	"testing"
+)
+
+func hd(t *testing.T, s string) []byte {
+	t.Helper()
+	b, err := hex.DecodeString(s)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return b
+}
+
+// test vector from https://tools.ietf.org/html/rfc6979#appendix-A.2.5
+func TestGenerateNonceRFC6979(t *testing.T) {
+	initP256SHA256TAI()
+	v := p256SHA256TAI
+
+	SK := &PrivateKey{
+		d: new(big.Int).SetBytes(hd(t, "C9AFA9D845BA75166B5C215767B1D6934E50C3DB36E89B127B8A622B120F6721")),
+		PublicKey: PublicKey{
+			X:     new(big.Int).SetBytes(hd(t, "60FED4BA255A9D31C961EB74C6356D68C049B8923B61FA6CE669622E60F29FB6")),
+			Y:     new(big.Int).SetBytes(hd(t, "7903FE1008B8BC99A41AE9E95628BC64F2F1B20C2D7E9F5177A3C294D4462299")),
+			Curve: elliptic.P256(),
+		},
+	}
+	m := []byte("sample")
+
+	if got, want := v.aux.GenerateNonce(SK, m).Bytes(),
+		hd(t, "A6E3C57DD01ABE90086538398355DD4C3B17AA873382B0F24D6129493D8AAD60"); !bytes.Equal(got, want) {
+		t.Errorf("k: %x, want %x", got, want)
+	}
+}


### PR DESCRIPTION
Implements [rfc6979](https://tools.ietf.org/html/rfc6979) for 
https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-vrf-06#section-5.4.2.2