### PR TITLE
ECVRF Prove

### DIFF
--- a/go/vrf/ecvrf.go
+++ b/go/vrf/ecvrf.go
@@ -128,9 +128,9 @@ func (p ECVRFParams) Prove(sk *PrivateKey, alpha []byte) []byte {
 	c := p.hashPoints(Hx, Hy, Gx, Gy, Ux, Uy, Vx, Vy)
 
 	// 7.  s = (k + c*x) mod q
-	s1 := new(big.Int).Mul(c, sk.d)
-	s2 := new(big.Int).Add(k, s1)
-	s := new(big.Int).Mod(s2, p.ec.Params().N)
+	s := new(big.Int).Mul(c, sk.d)
+	s.Add(k, s)
+	s.Mod(s, p.ec.Params().N)
 
 	// 8.  pi_string = point_to_string(Gamma) || int_to_string(c, n) || int_to_string(s, qLen)
 	pi := new(bytes.Buffer)

--- a/go/vrf/ecvrf.go
+++ b/go/vrf/ecvrf.go
@@ -111,7 +111,7 @@ type ECVRFAux interface {
 func (p ECVRFParams) Prove(sk *PrivateKey, alpha []byte) []byte {
 	// 1.  Use SK to derive the VRF secret scalar x and the VRF public key Y = x*B
 	// 2.  H = ECVRF_hash_to_curve(suite_string, Y, alpha_string)
-	Hx, Hy := p.aux.HashToCurve(sk.Public(), alpha)
+	Hx, Hy := p.aux.HashToCurve(sk.Public(), alpha) // suite_string is implicitly used in HashToCurve
 
 	// 3.  h_string = point_to_string(H)
 	hString := p.aux.PointToString(Hx, Hy)

--- a/go/vrf/ecvrf_p256_sha256_tai.go
+++ b/go/vrf/ecvrf_p256_sha256_tai.go
@@ -223,7 +223,6 @@ var one = big.NewInt(1)
 // VRF input alpha remain secret.
 //
 // Inputs:
-// - `suite` - a single octet specifying ECVRF ciphersuite.
 // - `pub`   - public key, an EC point
 // - `alpha` - value to be hashed, an octet string
 // Output:

--- a/go/vrf/ecvrf_p256_sha256_tai.go
+++ b/go/vrf/ecvrf_p256_sha256_tai.go
@@ -38,7 +38,7 @@ func initP256SHA256TAI() {
 	p := &ECVRFParams{
 		suite:    0x01,            // int_to_string(1, 1)
 		ec:       elliptic.P256(), // NIST P-256 elliptic curve, [FIPS-186-4] (Section D.1.2.3).
-		fieldLen: 32,              // Params().BitSize / 8 = 2n
+		fieldLen: 32,              // Params().BitSize / 8 = 2n. Must be a multiple of 2.
 		qLen:     32,              // Params().N.BitLen
 		ptLen:    33,              // Size of encoded EC point
 		cofactor: big.NewInt(1),

--- a/go/vrf/ecvrf_p256_sha256_tai.go
+++ b/go/vrf/ecvrf_p256_sha256_tai.go
@@ -240,7 +240,6 @@ func (a p256SHA256TAIAux) hashToCurve(pub *PublicKey, alpha []byte) (Hx, Hy *big
 	pkStr := a.PointToString(pub.X, pub.Y)
 
 	// 3.  one_string = 0x01 = int_to_string(1, 1), a single octet with value 1
-	oneStr := []byte{0x01}
 
 	// 4.  H = "INVALID"
 	h := a.params.hash.New()
@@ -248,16 +247,14 @@ func (a p256SHA256TAIAux) hashToCurve(pub *PublicKey, alpha []byte) (Hx, Hy *big
 	// 5.  While H is "INVALID" or H is EC point at infinity:
 	var err error
 	for Hx == nil || err != nil || (zero.Cmp(Hx) == 0 && zero.Cmp(Hy) == 0) {
-		// A.  ctr_string = int_to_string(ctr, 1)
-		ctrString := []byte{ctr}
+		// A. ctr_string = int_to_string(ctr, 1)
 		// B.  hash_string = Hash(suite_string || one_string ||
 		//     PK_string || alpha_string || ctr_string)
 		h.Reset()
-		h.Write([]byte{a.params.suite})
-		h.Write(oneStr)
+		h.Write([]byte{a.params.suite, 0x01})
 		h.Write(pkStr)
 		h.Write(alpha)
-		h.Write(ctrString)
+		h.Write([]byte{ctr}) // ctr_string = int_to_string(ctr, 1)
 		hashString := h.Sum(nil)
 		// C.  H = arbitrary_string_to_point(hash_string)
 		Hx, Hy, err = a.ArbitraryStringToPoint(hashString)

--- a/go/vrf/ecvrf_p256_sha256_tai.go
+++ b/go/vrf/ecvrf_p256_sha256_tai.go
@@ -74,6 +74,10 @@ func (a p256SHA256TAIAux) StringToPoint(s []byte) (x, y *big.Int, err error) {
 	return x, y, nil
 }
 
+func (a p256SHA256TAIAux) IntToString(x *big.Int, xLen uint) []byte {
+	return i2osp(x, xLen) // RFC8017 Section 4.1 (big endian representation)
+}
+
 // ArbitraryString2Point returns StringToPoint(0x02 || h).
 // Attempts to interpret an arbitrary string as a compressed elliptic code point.
 // The input h is a 32-octet string.  Returns either an EC point or "INVALID".

--- a/go/vrf/ecvrf_p256_sha256_tai_test.go
+++ b/go/vrf/ecvrf_p256_sha256_tai_test.go
@@ -144,8 +144,8 @@ func TestECVRF_P256_SHA256_TAI(t *testing.T) {
 
 			pi := new(bytes.Buffer)
 			pi.Write(v.aux.PointToString(Gx, Gy))
-			pi.Write(c.Bytes())
-			pi.Write(s.Bytes())
+			pi.Write(v.aux.IntToString(c, v.fieldLen/2)) // 2n = fieldLen
+			pi.Write(v.aux.IntToString(s, v.qLen))
 
 			if got := pi.Bytes(); !bytes.Equal(got, tc.pi) {
 				t.Errorf("pi: %x, want %x", got, tc.pi)

--- a/go/vrf/ecvrf_p256_sha256_tai_test.go
+++ b/go/vrf/ecvrf_p256_sha256_tai_test.go
@@ -20,6 +20,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"math/big"
+	"sync"
 	"testing"
 )
 
@@ -148,6 +149,32 @@ func TestECVRF_P256_SHA256_TAI(t *testing.T) {
 
 			if got := pi.Bytes(); !bytes.Equal(got, tc.pi) {
 				t.Errorf("pi: %x, want %x", got, tc.pi)
+			}
+
+			if pi := v.Prove(sk, tc.alpha); !bytes.Equal(pi, tc.pi) {
+				t.Errorf("Prove(%s): %x, want %x", tc.alpha, pi, tc.pi)
+			}
+		})
+	}
+}
+
+func BenchmarkProveECVRFP256SHA256TAI(b *testing.B) {
+	v := ECVRFP256SHA256TAI()
+	sk := NewKey(v.Params().ec,
+		hd(b, "2ca1411a41b17b24cc8c3b089cfd033f1920202a6c0de8abb97df1498d50d2c8"))
+	m1 := []byte("data1")
+	for _, routines := range []int{1, 2, 4, 8, 16, 32, 64, 128} {
+		b.Run(fmt.Sprintf("%d goroutines", routines), func(b *testing.B) {
+			var wg sync.WaitGroup
+			defer wg.Wait()
+			for i := 0; i < routines; i++ {
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					for n := 0; n < b.N/routines; n++ {
+						v.Prove(sk, m1)
+					}
+				}()
 			}
 		})
 	}


### PR DESCRIPTION
- init.Once semantics like the golang `crypto` libraries.
- Skeleton ECVRF interface
- Benchmark test

https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-vrf-06#section-5.1

Depends on #8 